### PR TITLE
Origin/feature/raz 531 vnics names ignore

### DIFF
--- a/package/cloudshell/cp/vcenter/models/ActionResult.py
+++ b/package/cloudshell/cp/vcenter/models/ActionResult.py
@@ -1,8 +1,6 @@
-class Test(object):
-    pass
+
 
 class ActionResult(object):
-
     def __init__(self):
         self.actionId = '',
         self.type = '',
@@ -10,22 +8,3 @@ class ActionResult(object):
         self.errorMessage = '',
         self.success = True,
         self.updatedInterface = ''
-
-
-class CustomActionResult(ActionResult):
-    def __init__(self):
-        super(CustomActionResult, self).__init__()
-        self.network_name = ''
-
-    def get_base_class(self):
-        action = ActionResult()
-        for att in self._get_attributes_names(action):
-            if hasattr(self, att):
-                value = str(getattr(self, att))
-                setattr(action, att, value)
-
-        return action
-
-    @staticmethod
-    def _get_attributes_names(cls):
-        return (attr for attr in dir(cls) if not attr.startswith("__"))

--- a/package/cloudshell/tests/test_common/test_utilities/test_command_result.py
+++ b/package/cloudshell/tests/test_common/test_utilities/test_command_result.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 
-from cloudshell.cp.vcenter.models.ActionResult import Test
 from cloudshell.cp.vcenter.models.ActionResult import ActionResult
 from cloudshell.cp.vcenter.models.ConnectionResult import ConnectionResult
 from cloudshell.cp.vcenter.models.DriverResponse import DriverResponse, DriverResponseRoot


### PR DESCRIPTION
#531 

rewriting the connect_orchestrator

fixing the connect_orchestrator to support the selection of vnics when trying to connect more then one route in reservation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/550)
<!-- Reviewable:end -->