### PR TITLE
changed the dvswitch name_generator to include the name of the dvswitch.

### DIFF
--- a/orchestration_service/orchestrator.py
+++ b/orchestration_service/orchestrator.py
@@ -62,7 +62,7 @@ class DeployAppOrchestrationDriver(object):
         # Set live status - deployment done
         session.SetResourceLiveStatus(deployment_result.LogicalResourceName, "Online", "Active")
 
-        success_msg = self._format_message(deployed_app_name, 'deployed Successfully')
+        success_msg = self._format_message(deployed_app_name, 'Deployed Successfully')
         logger.info(success_msg)
         return success_msg
 

--- a/package/cloudshell/cp/vcenter/commands/connect_dvswitch.py
+++ b/package/cloudshell/cp/vcenter/commands/connect_dvswitch.py
@@ -42,7 +42,7 @@ class VirtualSwitchConnectCommand:
         if not default_network_instance:
             raise ValueError('Default Network {0} not found'.format(default_network_name))
 
-        mappings = self._prepare_mappings(vm_network_mappings)
+        mappings = self._prepare_mappings(default_network_name, vm_network_mappings)
 
         updated_mappings = self.virtual_switch_to_machine_connector.connect_by_mapping(
             si, vm, mappings, default_network_instance, reserved_networks, logger)
@@ -60,12 +60,13 @@ class VirtualSwitchConnectCommand:
 
         return connection_results
 
-    def _prepare_mappings(self, vm_network_mappings):
+    def _prepare_mappings(self, dv_switch_name, vm_network_mappings):
         mappings = []
         # create mapping
         for vm_network_mapping in vm_network_mappings:
             vm_network_mapping.dv_port_name = \
-                self.dv_port_group_name_generator.generate_port_group_name(vm_network_mapping.vlan_id,
+                self.dv_port_group_name_generator.generate_port_group_name(dv_switch_name,
+                                                                           vm_network_mapping.vlan_id,
                                                                            vm_network_mapping.vlan_spec)
 
             vm_network_mapping.vlan_id = \

--- a/package/cloudshell/cp/vcenter/network/dvswitch/name_generator.py
+++ b/package/cloudshell/cp/vcenter/network/dvswitch/name_generator.py
@@ -1,12 +1,14 @@
+MAX_DVSWITCH_LENGTH = 60
 QS_NAME_PREFIX = 'QS'
 VLAN = 'VLAN'
-NAME_FORMAT = '{0}_{1}_{2}_{3}'
+NAME_FORMAT = '{0}_{1}_{2}_{3}_{4}'
 
 
 class DvPortGroupNameGenerator(object):
     @staticmethod
-    def generate_port_group_name(vlan_id, vlan_type):
-        return NAME_FORMAT.format(QS_NAME_PREFIX, VLAN, str(vlan_id), str(vlan_type))
+    def generate_port_group_name(dv_switch_name, vlan_id, vlan_type):
+        dv_switch_name = dv_switch_name[:MAX_DVSWITCH_LENGTH]
+        return NAME_FORMAT.format(QS_NAME_PREFIX, dv_switch_name, VLAN, str(vlan_id), str(vlan_type))
 
     @staticmethod
     def is_generated_name(name):

--- a/package/cloudshell/tests/test_commands/test_connect_orchestrator.py
+++ b/package/cloudshell/tests/test_commands/test_connect_orchestrator.py
@@ -116,7 +116,7 @@ class TestCommandOrchestrator(TestCase):
                                  vnic_name=vnic_name,
                                  requested_vnic=vnic_name,
                                  vm_uuid=vm_uuid,
-                                 network_name=self.portgroup_name.generate_port_group_name(vlan_id, mode),
+                                 network_name=self.portgroup_name.generate_port_group_name('dvSwitch', vlan_id, mode),
                                  network_key='aa')
             res.append(r)
         self.connector.connect_to_networks = Mock(return_value=res)

--- a/package/cloudshell/tests/test_network/test_dvswitch/test_name_generator.py
+++ b/package/cloudshell/tests/test_network/test_dvswitch/test_name_generator.py
@@ -9,7 +9,18 @@ class TestDvPortGroupCreator(TestCase):
         gen = DvPortGroupNameGenerator()
 
         # act
-        name = gen.generate_port_group_name('id', 'Trunk')
+        name = gen.generate_port_group_name('some_dv_switch', 'id', 'Trunk')
 
         # assert
-        self.assertEqual('QS_VLAN_id_Trunk', name)
+        self.assertEqual('QS_some_dv_switch_VLAN_id_Trunk', name)
+
+    def test_long_dvswitch_name(self):
+        # arrange
+        gen = DvPortGroupNameGenerator()
+        dv_switch_name = "some_dv_switch__some_dv_switch__some_dv_switch__some_dv_switch__some_dv_switch__some_dv_switch__some_dv_switch_"
+
+        # act
+        name = gen.generate_port_group_name(dv_switch_name, 'id', 'Trunk')
+
+        # assert
+        self.assertEqual('QS_some_dv_switch__some_dv_switch__some_dv_switch__some_dv_swit_VLAN_id_Trunk', name)


### PR DESCRIPTION
## Description
Changed the dvswitch name_generator to include the name of the dvswitch.
If the name of the dvSwitch is too long than it will be truncate to fit the max length of 80 chars

## Related Stories


## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/633)
<!-- Reviewable:end -->