### PR TITLE
default dvswitch name will be inserted correctly to the generated por…

### DIFF
--- a/package/cloudshell/cp/vcenter/commands/connect_dvswitch.py
+++ b/package/cloudshell/cp/vcenter/commands/connect_dvswitch.py
@@ -21,15 +21,17 @@ class VirtualSwitchConnectCommand:
         self.vlan_spec_factory = vlan_spec_factory
         self.vlan_id_range_parser = vlan_id_range_parser
 
-    def connect_to_networks(self, si, logger, vm_uuid, vm_network_mappings, default_network_name, reserved_networks):
+    def connect_to_networks(self, si, logger, vm_uuid, vm_network_mappings, default_network_name,
+                            reserved_networks, dv_switch_name):
         """
         Connect VM to Network
         :param si: VmWare Service Instance - defined connection to vCenter
+        :param logger:
         :param vm_uuid: <str> UUID for VM
         :param vm_network_mappings: <collection of 'VmNetworkMapping'>
         :param default_network_name: <str> Full Network name - likes 'DataCenterName/NetworkName'
         :param reserved_networks:
-        :param logger:
+        :param dv_switch_name: <str> Default dvSwitch name
         :return: None
         """
         vm = self.pv_service.find_by_uuid(si, vm_uuid)
@@ -42,7 +44,7 @@ class VirtualSwitchConnectCommand:
         if not default_network_instance:
             raise ValueError('Default Network {0} not found'.format(default_network_name))
 
-        mappings = self._prepare_mappings(default_network_name, vm_network_mappings)
+        mappings = self._prepare_mappings(dv_switch_name=dv_switch_name, vm_network_mappings=vm_network_mappings)
 
         updated_mappings = self.virtual_switch_to_machine_connector.connect_by_mapping(
             si, vm, mappings, default_network_instance, reserved_networks, logger)

--- a/package/cloudshell/cp/vcenter/commands/connect_orchestrator.py
+++ b/package/cloudshell/cp/vcenter/commands/connect_orchestrator.py
@@ -193,12 +193,13 @@ class ConnectionCommandOrchestrator(object):
             self.logger.debug('connecting vm({0}) with the mappings'.format(vm_uuid,
                                                                             jsonpickle.encode(action_mappings,
                                                                                               unpicklable=False)))
-            connection_results = self.connector.connect_to_networks(si,
-                                                                    logger,
-                                                                    vm_uuid,
-                                                                    action_mappings.set_mapping,
-                                                                    self.default_network,
-                                                                    self.reserved_networks)
+            connection_results = self.connector.connect_to_networks(si=si,
+                                                                    logger=logger,
+                                                                    vm_uuid=vm_uuid,
+                                                                    vm_network_mappings=action_mappings.set_mapping,
+                                                                    default_network_name=self.default_network,
+                                                                    reserved_networks=self.reserved_networks,
+                                                                    dv_switch_name=self.dv_switch_name)
 
             connection_res_map = self._prepare_connection_results_for_extraction(connection_results)
             act_by_mode_by_vlan = self._group_action_by_vlan_id(set_vlan_actions)

--- a/package/cloudshell/tests/test_commands/test_connect_vm.py
+++ b/package/cloudshell/tests/test_commands/test_connect_vm.py
@@ -56,7 +56,8 @@ class TestVirtualSwitchToMachineDisconnectCommand(TestCase):
                                                               vm_uuid=self.vm_uuid,
                                                               vm_network_mappings=[mapping],
                                                               default_network_name='default_network',
-                                                              reserved_networks=[])
+                                                              reserved_networks=[],
+                                                              dv_switch_name='')
 
         # assert
         self.assertTrue(self.vlan_id_range_parser.parse_vlan_id.called_with(self.vlan_id))


### PR DESCRIPTION
## Description
default dvswitch name will be inserted correctly to the generated port group name

## Related Stories
List related PRs against other branches:

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/637)
<!-- Reviewable:end -->