### PR TITLE
renaming vCenterCloneFromVMResourceModel to VCenterDeployVMFromLinked…

### DIFF
--- a/deployment_drivers/deploy_clone_from_vm/driver.py
+++ b/deployment_drivers/deploy_clone_from_vm/driver.py
@@ -1,7 +1,7 @@
 import jsonpickle
 from cloudshell.api.cloudshell_api import InputNameValue
 from cloudshell.cp.vcenter.models.DeployFromTemplateDetails import DeployFromTemplateDetails
-from cloudshell.cp.vcenter.models.VCenterDeployVMFromLinkedCloneResourceModel import vCenterCloneFromVMResourceModel
+from cloudshell.cp.vcenter.models.VCenterDeployVMFromLinkedCloneResourceModel import VCenterDeployVMFromLinkedCloneResourceModel
 
 from cloudshell.cp.vcenter.common.cloud_shell.driver_helper import CloudshellDriverHelper
 from cloudshell.cp.vcenter.common.model_factory import ResourceModelParser


### PR DESCRIPTION
## Description
renaming vCenterCloneFromVMResourceModel to VCenterDeployVMFromLinked

## Related Stories
#642 

## Breaking
NO
Feature/gil 642 portgroup remove att fix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/673)
<!-- Reviewable:end -->
