### PR TITLE
When VM already deleted.

### DIFF
--- a/package/cloudshell/cp/vcenter/commands/destroy_vm.py
+++ b/package/cloudshell/cp/vcenter/commands/destroy_vm.py
@@ -31,8 +31,14 @@ class DestroyVirtualMachineCommand(object):
                                            logger=logger)
         # find vm
         vm = self.pv_service.find_by_uuid(si, vm_uuid)
-        # destroy vm
-        result = self.pv_service.destroy_vm(vm=vm, logger=logger)
+
+        if vm is not None:
+            # destroy vm
+            result = self.pv_service.destroy_vm(vm=vm, logger=logger)
+        else:
+            logger.info("Could not find the VM {0},will remove the resource.".format(vm_name))
+            result = None
+
         # delete resources
         self.resource_remover.remove_resource(session=session, resource_full_name=vm_name)
         return result


### PR DESCRIPTION
## Description
Fix for :Cannot "Delete" command on app resource if underlying VM no longer exists in vcenter
Now: removes the resource from  the DB.
## Related Stories
#505  

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/678)
<!-- Reviewable:end -->
