### PR TITLE
Feature/alex 713 remove delete command

### DIFF
--- a/package/cloudshell/cp/vcenter/commands/command_orchestrator.py
+++ b/package/cloudshell/cp/vcenter/commands/command_orchestrator.py
@@ -277,25 +277,6 @@ class CommandOrchestrator(object):
         return set_command_result(result=res, unpicklable=False)
 
     # remote command
-    def destroy_vm(self, context, ports):
-        """
-        Destroy Vm Command, will destroy the vm and remove the resource
-
-        :param models.QualiDriverModels.ResourceRemoteCommandContext context: the context the command runs on
-        :param list[string] ports: the ports of the connection between the remote resource and the local resource, NOT IN USE!!!
-        """
-        resource_details = self._parse_remote_model(context)
-        reservation_id = context.remote_reservation.reservation_id
-        # execute command
-        res = self.command_wrapper.execute_command_with_connection(
-            context,
-            self.destroy_virtual_machine_command.destroy,
-            resource_details.vm_uuid,
-            resource_details.fullname,
-            reservation_id)
-        return set_command_result(result=res, unpicklable=False)
-
-    # remote command
     def destroy_vm_only(self, context, ports):
         """
         Destroy Vm Command, will only destroy the vm and will not remove the resource
@@ -304,14 +285,12 @@ class CommandOrchestrator(object):
         :param list[string] ports: the ports of the connection between the remote resource and the local resource, NOT IN USE!!!
         """
         resource_details = self._parse_remote_model(context)
-        reservation_id = context.remote_reservation.reservation_id
         # execute command
         res = self.command_wrapper.execute_command_with_connection(
             context,
             self.destroy_virtual_machine_command.destroy_vm_only,
             resource_details.vm_uuid,
-            resource_details.fullname,
-            reservation_id)
+            resource_details.fullname)
         return set_command_result(result=res, unpicklable=False)
 
     # remote command

--- a/package/cloudshell/cp/vcenter/commands/destroy_vm.py
+++ b/package/cloudshell/cp/vcenter/commands/destroy_vm.py
@@ -15,6 +15,7 @@ class DestroyVirtualMachineCommand(object):
         self.resource_remover = resource_remover
         self.disconnector = disconnector
 
+    # obsolete
     def destroy(self, si, logger, session, vcenter_data_model, vm_uuid, vm_name, reservation_id):
         """
         :param si:
@@ -43,23 +44,18 @@ class DestroyVirtualMachineCommand(object):
         self.resource_remover.remove_resource(session=session, resource_full_name=vm_name)
         return result
 
-    def destroy_vm_only(self, si, logger, session, vcenter_data_model, vm_uuid, vm_name, reservation_id):
+    def destroy_vm_only(self, si, logger, session, vcenter_data_model, vm_uuid, vm_name):
         """
         :param logger:
         :param CloudShellAPISession session:
         :param str vm_name: This is the resource name
         :return:
         """
-        # disconnect
-        self._disconnect_all_my_connectors(session=session,
-                                           resource_name=vm_name,
-                                           reservation_id=reservation_id,
-                                           logger=logger)
         # find vm
         vm = self.pv_service.find_by_uuid(si, vm_uuid)
         if vm is not None:
             # destroy vm
-            result = self.pv_service.destroy_vm(vm=vm,logger=logger)
+            result = self.pv_service.destroy_vm(vm=vm, logger=logger)
         else:
             resource___format = "Could not find the VM {0},will remove the resource.".format(vm_name)
             logger.info(resource___format)

--- a/package/cloudshell/tests/test_commands/test_command_orchestrator.py
+++ b/package/cloudshell/tests/test_commands/test_command_orchestrator.py
@@ -52,9 +52,9 @@ class TestCommandOrchestrator(TestCase):
         # assert
         self.assertTrue(self.command_orchestrator.command_wrapper.execute_command_with_connection.called)
 
-    def test_destroy_vm(self):
+    def test_destroy_vm_only(self):
         # act
-        self.command_orchestrator.destroy_vm(self.context, self.ports)
+        self.command_orchestrator.destroy_vm_only(self.context, self.ports)
         # assert
         self.assertTrue(self.command_orchestrator.command_wrapper.execute_command_with_connection.called)
 

--- a/package/cloudshell/tests/test_commands/test_destroy_vm.py
+++ b/package/cloudshell/tests/test_commands/test_destroy_vm.py
@@ -116,8 +116,7 @@ class TestDestroyVirtualMachineCommand(unittest.TestCase):
                                         session=session,
                                         vcenter_data_model=vcenter_data_model,
                                         vm_uuid=uuid,
-                                        vm_name=resource_name,
-                                        reservation_id="reservation_id")
+                                        vm_name=resource_name)
 
         # assert
         self.assertTrue(res)

--- a/vcentershell_driver/driver.py
+++ b/vcentershell_driver/driver.py
@@ -26,9 +26,6 @@ class VCenterShellDriver (ResourceDriverInterface):
     def disconnect(self, context, ports, network_name):
         return self.command_orchestrator.disconnect(context, ports, network_name)
 
-    def destroy_vm(self, context, ports):
-        return self.command_orchestrator.destroy_vm(context, ports)
-
     def destroy_vm_only(self, context, ports):
         return self.command_orchestrator.destroy_vm_only(context, ports)
 

--- a/vcentershell_driver/drivermetadata.xml
+++ b/vcentershell_driver/drivermetadata.xml
@@ -12,9 +12,6 @@
             <Command Description="" DisplayName="Disconnect All" Name="disconnect_all" Tags="allow_unreserved" />
             <Command Description="" DisplayName="Disconnect" Name="disconnect" Tags="allow_unreserved" />
         </Category>
-        <Category Name="App Management">
-            <Command Description="" DisplayName="Delete" Name="destroy_vm" Tags="remote_app_management,allow_shared" />
-        </Category>
         <Category Name="Hidden Commands">
             <Command Description="" DisplayName="Power Cycle" Name="PowerCycle" Tags="power" />
             <Command Description="" DisplayName="Delete VM Only" Name="destroy_vm_only" Tags="remote_app_management" />

--- a/vcentershell_driver/tests/test_vcenter_driver.py
+++ b/vcentershell_driver/tests/test_vcenter_driver.py
@@ -58,14 +58,6 @@ class TestCommandOrchestrator(TestCase):
         self.assertIsNotNone(res)
         self.assertTrue(self.driver.command_orchestrator.disconnect.called_with(self.context, self.ports, network_name))
 
-    def test_destroy_vm(self):
-        self.setUp()
-
-        res = self.driver.destroy_vm(self.context, self.ports)
-
-        self.assertIsNotNone(res)
-        self.assertTrue(self.driver.command_orchestrator.destroy_vm.called_with(self.context, self.ports))
-
     def test_destroy_vm_only(self):
         self.setUp()
 


### PR DESCRIPTION
## Description
1. Removed Delete command from shell
2. Removed disconnect vlans from destroy_vm_only (server will handle this from now)

## Related Stories
#713

## Breaking
YES

## Breaking changes
Removed Delete command from the vCenterShell driver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/740)
<!-- Reviewable:end -->
