### PR TITLE
enhance save/restore snapshot 

### DIFF
--- a/package/cloudshell/cp/vcenter/commands/restore_snapshot.py
+++ b/package/cloudshell/cp/vcenter/commands/restore_snapshot.py
@@ -1,6 +1,7 @@
 from cloudshell.cp.vcenter.common.vcenter.task_waiter import SynchronousTaskWaiter
 from cloudshell.cp.vcenter.common.vcenter.vm_snapshots import SnapshotRetriever
 from cloudshell.cp.vcenter.common.vcenter.vmomi_service import pyVmomiService
+from cloudshell.cp.vcenter.exceptions.snapshot_not_found import SnapshotNotFoundException
 
 
 class SnapshotRestoreCommand:
@@ -44,7 +45,7 @@ class SnapshotRestoreCommand:
         snapshots = SnapshotRetriever.get_vm_snapshots(vm)
 
         if snapshot_name not in snapshots:
-            raise Exception('Snapshot {0} was not found'.format(snapshot_name))
+            raise SnapshotNotFoundException('Snapshot {0} was not found'.format(snapshot_name))
 
         return snapshots[snapshot_name]
 

--- a/package/cloudshell/cp/vcenter/common/vcenter/vm_snapshots.py
+++ b/package/cloudshell/cp/vcenter/common/vcenter/vm_snapshots.py
@@ -6,6 +6,25 @@ class SnapshotRetriever:
         pass
 
     @staticmethod
+    def get_current_snapshot_name(vm):
+        """
+        Returns the name of the current snapshot
+        :param vm: Virtual machine to find current snapshot name
+        :return: Snapshot name
+        :rtype str
+        """
+        all_snapshots = SnapshotRetriever.get_vm_snapshots(vm)
+        # noinspection PyProtectedMember
+        if not vm.snapshot:
+            return None
+        current_snapshot_id = vm.snapshot.currentSnapshot._moId
+        for snapshot_name in all_snapshots.keys():
+            # noinspection PyProtectedMember
+            if all_snapshots[snapshot_name]._moId == current_snapshot_id:
+                return snapshot_name
+        return None
+
+    @staticmethod
     def get_vm_snapshots(vm):
         """
         Returns dictinary of snapshots of a given virtual machine
@@ -26,7 +45,7 @@ class SnapshotRetriever:
         :param snapshots: list of snapshots to examine
         :param snapshot_location: current path of snapshots
         :return: dictinary of snapshot path and snapshot instances
-        :rtype: dict
+        :rtype: dict(str,vim.vm.Snapshot)
         """
         snapshot_paths = {}
 
@@ -35,7 +54,7 @@ class SnapshotRetriever:
 
         for snapshot in snapshots:
             if snapshot_location:
-                current_snapshot_path = snapshot_location + '/' + snapshot.name
+                current_snapshot_path = SnapshotRetriever.combine(snapshot_location, snapshot.name)
             else:
                 current_snapshot_path = snapshot.name
 
@@ -45,3 +64,14 @@ class SnapshotRetriever:
             snapshot_paths.update(child_snapshots)
 
         return snapshot_paths
+
+    @staticmethod
+    def combine(base_snapshot_location, snapshot_name):
+        """
+        Combines snapshot path
+        :param base_snapshot_location:
+        :param snapshot_name:
+        :return: combined snapshot path
+        :rtype str
+        """
+        return base_snapshot_location + '/' + snapshot_name

--- a/package/cloudshell/cp/vcenter/exceptions/snapshot_exists.py
+++ b/package/cloudshell/cp/vcenter/exceptions/snapshot_exists.py
@@ -1,0 +1,2 @@
+class SnapshotAlreadyExistsException(Exception):
+    pass

--- a/package/cloudshell/cp/vcenter/exceptions/snapshot_not_found.py
+++ b/package/cloudshell/cp/vcenter/exceptions/snapshot_not_found.py
@@ -1,0 +1,2 @@
+class SnapshotNotFoundException(Exception):
+    pass

--- a/package/cloudshell/tests/test_commands/test_restore_snapshot.py
+++ b/package/cloudshell/tests/test_commands/test_restore_snapshot.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from mock import Mock, patch
 
 from cloudshell.cp.vcenter.commands.restore_snapshot import SnapshotRestoreCommand
+from cloudshell.cp.vcenter.exceptions.snapshot_not_found import SnapshotNotFoundException
 
 
 class TestSnapshotRestoreCommand(TestCase):
@@ -43,5 +44,5 @@ class TestSnapshotRestoreCommand(TestCase):
         mock_get_vm_snapshots.return_value = {'snap1': Mock()}
 
         # Act + Assert
-        self.assertRaises(Exception, snapshot_restore_command.restore_snapshot, si, Mock(), 'machine1',
+        self.assertRaises(SnapshotNotFoundException, snapshot_restore_command.restore_snapshot, si, Mock(), 'machine1',
                           'NOT_EXISTING_SNAPSHOT')

--- a/package/cloudshell/tests/test_commands/test_save_snapshot.py
+++ b/package/cloudshell/tests/test_commands/test_save_snapshot.py
@@ -1,12 +1,17 @@
 from unittest import TestCase
 
-from mock import Mock
+from mock import Mock, patch
 
 from cloudshell.cp.vcenter.commands.save_snapshot import SaveSnapshotCommand
+from cloudshell.cp.vcenter.exceptions.snapshot_exists import SnapshotAlreadyExistsException
+
+GET_VM_SNAPSHOTS = 'cloudshell.cp.vcenter.commands.save_snapshot.SnapshotRetriever.get_vm_snapshots'
+
+GET_CURRENT_SNAPSHOT_NAME = 'cloudshell.cp.vcenter.commands.save_snapshot.SnapshotRetriever.get_current_snapshot_name'
 
 
 class TestSaveSnapshotCommand(TestCase):
-    def test_save_snapshot_succeeds(self):
+    def test_save_snapshot_should_succeed_when_there_is_no_snapshot(self):
         vm = Mock()
 
         pyvmomi_service = Mock()
@@ -16,10 +21,57 @@ class TestSaveSnapshotCommand(TestCase):
         si = Mock()
 
         # Act
-        save_snapshot_command.save_snapshot(si=si,
-                                            logger=Mock(),
-                                            vm_uuid='machine1',
-                                            snapshot_name='new_snapshot')
+        with patch(GET_CURRENT_SNAPSHOT_NAME) as get_current_snapshot_name:
+            with patch(GET_VM_SNAPSHOTS) as get_vm_snapshots:
+                get_current_snapshot_name.return_value = None
+                get_vm_snapshots.return_value = {}
+                save_snapshot_command.save_snapshot(si=si,
+                                                    logger=Mock(),
+                                                    vm_uuid='machine1',
+                                                    snapshot_name='new_snapshot')
 
         # Assert
         vm.CreateSnapshot.called_with('new_snapshot', 'Created by CloudShell vCenterShell', False, True)
+
+    def test_save_snapshot_should_succeed_when_snapshot_with_the_same_name_does_not_exists(self):
+        vm = Mock()
+
+        pyvmomi_service = Mock()
+        pyvmomi_service.find_by_uuid = Mock(return_value=vm)
+
+        save_snapshot_command = SaveSnapshotCommand(pyvmomi_service, Mock())
+        si = Mock()
+
+        # Act
+        with patch(GET_CURRENT_SNAPSHOT_NAME) as get_current_snapshot_name:
+            with patch(GET_VM_SNAPSHOTS) as get_vm_snapshots:
+                get_current_snapshot_name.return_value = 'snapshot1/snapshot2'
+                get_vm_snapshots.return_value = {'snapshot1/snapshot2': None, 'snapshot1': None}
+                save_snapshot_command.save_snapshot(si=si,
+                                                    logger=Mock(),
+                                                    vm_uuid='machine1',
+                                                    snapshot_name='new_snapshot')
+
+        # Assert
+        vm.CreateSnapshot.called_with('new_snapshot', 'Created by CloudShell vCenterShell', False, True)
+
+    def test_save_snapshot_should_fail_if_snaphost_exists(self):
+        vm = Mock()
+
+        pyvmomi_service = Mock()
+        pyvmomi_service.find_by_uuid = Mock(return_value=vm)
+
+        save_snapshot_command = SaveSnapshotCommand(pyvmomi_service, Mock())
+        si = Mock()
+
+        with patch(GET_CURRENT_SNAPSHOT_NAME) as get_current_snapshot_name:
+            with patch(GET_VM_SNAPSHOTS) as get_vm_snapshots:
+                    get_current_snapshot_name.return_value = 'snapshot1'
+                    get_vm_snapshots.return_value = {'snapshot1': None, 'snapshot1/snapshot2': None}
+
+                    # Act + Assert
+                    with self.assertRaises(SnapshotAlreadyExistsException):
+                        save_snapshot_command.save_snapshot(si=si,
+                                                            logger=Mock(),
+                                                            vm_uuid='machine1',
+                                                            snapshot_name='snapshot2')

--- a/package/cloudshell/tests/test_common/test_vcenter/test_vm_snapshots.py
+++ b/package/cloudshell/tests/test_common/test_vcenter/test_vm_snapshots.py
@@ -56,3 +56,21 @@ class TestSnapshotRetriever(unittest.TestCase):
 
         # assert
         self.assertSequenceEqual(all_snapshots.keys(), ['root', 'root/child'])
+
+    def test_combine_should_combine_base_snapshot_location_with_snapshot_name(self):
+        # Act
+        snapshot_path = SnapshotRetriever.combine('snapshot1/snapshot2', 'snapshot3')
+
+        # Assert
+        self.assertEqual(snapshot_path, 'snapshot1/snapshot2/snapshot3')
+
+    def test_cet_current_snapshot_returns_none_when_no_snapshot_exists(self):
+        # Arrange
+        vm = Mock()
+        vm.snapshot = None
+
+        # Act
+        current_snapshot_name = SnapshotRetriever.get_current_snapshot_name(vm)
+
+        # assert
+        self.assertIsNone(current_snapshot_name)


### PR DESCRIPTION
## Description
* Save snapshot should fail in case a snapshot with the same full name (case sensitive) exists, with message “A snapshot of this name already exist under this VM. Please select a different name for the VM snapshot.”
* Snapshot Name is case sensitive, fail in case full name isn’t unique with message “Not possible to restore the snapshot, there are multiple snapshots under this VM with the name ‘’.”

## Related Stories
connect #186

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/751)
<!-- Reviewable:end -->
