### PR TITLE
Set live status to offline before restoring snapshot

### DIFF
--- a/package/cloudshell/cp/vcenter/commands/command_orchestrator.py
+++ b/package/cloudshell/cp/vcenter/commands/command_orchestrator.py
@@ -424,6 +424,7 @@ class CommandOrchestrator(object):
         self.command_wrapper.execute_command_with_connection(context,
                                                              self.snapshot_restorer.restore_snapshot,
                                                              resource_details.vm_uuid,
+                                                             resource_details.fullname,
                                                              snapshot_name)
 
     def get_snapshots(self, context):


### PR DESCRIPTION
## Description
Before restoring a snapshot of a virtual machine, its live status is set to offline

## Related Stories
https://github.com/QualiSystems/AWS-Shell/issues/214

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/757)
<!-- Reviewable:end -->
