### PR TITLE
fix orchestration_save to use date and time for snapshot name

### DIFF
--- a/package/cloudshell/cp/vcenter/commands/command_orchestrator.py
+++ b/package/cloudshell/cp/vcenter/commands/command_orchestrator.py
@@ -1,5 +1,5 @@
 import time
-from datetime import date
+from datetime import datetime, date
 import jsonpickle
 from cloudshell.cp.vcenter.models.OrchestrationSaveResult import OrchestrationSaveResult
 from cloudshell.cp.vcenter.models.OrchestrationSavedArtifactsInfo import OrchestrationSavedArtifactsInfo
@@ -454,7 +454,7 @@ class CommandOrchestrator(object):
         :rtype: SavedResults
         """
         resource_details = self._parse_remote_model(context)
-        created_date = date.today()
+        created_date = datetime.now()
         snapshot_name = created_date.strftime('%y_%m_%d %H_%M_%S_%f')
         created_snapshot_path = self.save_snapshot(context=context, snapshot_name=snapshot_name)
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,4 +4,5 @@ unittest2
 mock
 teamcity-messages
 nose-exclude
+freezegun
 coveralls


### PR DESCRIPTION
## Description
fix orchestration_save to use date and time for snapshot name

## Related Stories
connect #749 

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/764)
<!-- Reviewable:end -->
