### PR TITLE
Minor changes in orchestration save

### DIFF
--- a/package/cloudshell/cp/vcenter/commands/command_orchestrator.py
+++ b/package/cloudshell/cp/vcenter/commands/command_orchestrator.py
@@ -464,13 +464,13 @@ class CommandOrchestrator(object):
         orchestration_saved_artifact.artifact_type = 'vcenter_snapshot'
         orchestration_saved_artifact.identifier = created_snapshot_path
 
-        saved_artifacts_info = OrchestrationSavedArtifactsInfo(
+        saved_artifact_info = OrchestrationSavedArtifactsInfo(
             resource_name=resource_details.cloud_provider,
             created_date=created_date,
             restore_rules={'requires_same_resource': True},
             saved_artifact=orchestration_saved_artifact)
 
-        orchestration_save_result = OrchestrationSaveResult(saved_artifacts_info)
+        orchestration_save_result = OrchestrationSaveResult(saved_artifact_info)
 
         return set_command_result(result=orchestration_save_result, unpicklable=False)
 
@@ -487,6 +487,6 @@ class CommandOrchestrator(object):
         :param saved_details:
         :return:
         """
-        saved_artifacts_info = get_result_from_command_output(saved_details)
-        snapshot_name = saved_artifacts_info['saved_artifacts_info']['saved_artifact']['identifier']
+        saved_artifact_info = get_result_from_command_output(saved_details)
+        snapshot_name = saved_artifact_info['saved_artifact_info']['saved_artifact']['identifier']
         return self.restore_snapshot(context=context, snapshot_name=snapshot_name)

--- a/package/cloudshell/cp/vcenter/commands/command_orchestrator.py
+++ b/package/cloudshell/cp/vcenter/commands/command_orchestrator.py
@@ -371,7 +371,6 @@ class CommandOrchestrator(object):
         """
         parse the remote resource model and adds its full name
         :type context: models.QualiDriverModels.ResourceRemoteCommandContext
-
         """
         if not context.remote_endpoints:
             raise Exception('no remote resources found in context: {0}', jsonpickle.encode(context, unpicklable=False))
@@ -465,7 +464,7 @@ class CommandOrchestrator(object):
         orchestration_saved_artifact.identifier = created_snapshot_path
 
         saved_artifact_info = OrchestrationSavedArtifactsInfo(
-            resource_name=resource_details.cloud_provider,
+            resource_name=resource_details.fullname,
             created_date=created_date,
             restore_rules={'requires_same_resource': True},
             saved_artifact=orchestration_saved_artifact)

--- a/package/cloudshell/cp/vcenter/models/OrchestrationSaveResult.py
+++ b/package/cloudshell/cp/vcenter/models/OrchestrationSaveResult.py
@@ -1,6 +1,6 @@
 class OrchestrationSaveResult(object):
-    def __init__(self, saved_artifacts_info):
+    def __init__(self, saved_artifact_info):
         """
-        :type saved_artifacts_info: OrchestrationSavedArtifactsInfo
+        :type saved_artifact_info: OrchestrationSavedArtifactsInfo
         """
-        self.saved_artifacts_info = saved_artifacts_info
+        self.saved_artifact_info = saved_artifact_info

--- a/package/cloudshell/tests/test_commands/test_command_orchestrator.py
+++ b/package/cloudshell/tests/test_commands/test_command_orchestrator.py
@@ -154,11 +154,11 @@ class TestCommandOrchestrator(TestCase):
             # Assert
             save_snapshot_mock.assert_called_once()
             saved_result_dict = jsonpickle.decode(saved_result)
-            self.assertEqual(saved_result_dict['saved_artifacts_info']['saved_artifact']['artifact_type'],
+            self.assertEqual(saved_result_dict['saved_artifact_info']['saved_artifact']['artifact_type'],
                              'vcenter_snapshot')
-            self.assertEqual(saved_result_dict['saved_artifacts_info']['saved_artifact']['identifier'], 'new_snapshot')
-            self.assertEqual(saved_result_dict['saved_artifacts_info']['resource_name'], 'vcenter')
-            self.assertIsNotNone(saved_result_dict['saved_artifacts_info']['created_date'])
+            self.assertEqual(saved_result_dict['saved_artifact_info']['saved_artifact']['identifier'], 'new_snapshot')
+            self.assertEqual(saved_result_dict['saved_artifact_info']['resource_name'], 'vcenter')
+            self.assertIsNotNone(saved_result_dict['saved_artifact_info']['created_date'])
 
     @freeze_time("1984-12-31 11:12:13.4567")
     def test_orchestration_save_snapshot_name_should_contain_full_datetime(self):
@@ -189,7 +189,7 @@ class TestCommandOrchestrator(TestCase):
         with patch(RESTORE_SNAPSHOT) as mock_restore_snapshot:
             # Act
             self.command_orchestrator.orchestration_restore(self.context, '''{
-      "saved_artifacts_info": {
+      "saved_artifact_info": {
         "resource_name": "ex cillum sed laboris",
         "created_date": "4313-10-12T18:03:15.053Z",
         "restore_rules": {

--- a/package/cloudshell/tests/test_commands/test_command_orchestrator.py
+++ b/package/cloudshell/tests/test_commands/test_command_orchestrator.py
@@ -157,7 +157,7 @@ class TestCommandOrchestrator(TestCase):
             self.assertEqual(saved_result_dict['saved_artifact_info']['saved_artifact']['artifact_type'],
                              'vcenter_snapshot')
             self.assertEqual(saved_result_dict['saved_artifact_info']['saved_artifact']['identifier'], 'new_snapshot')
-            self.assertEqual(saved_result_dict['saved_artifact_info']['resource_name'], 'vcenter')
+            self.assertEqual(saved_result_dict['saved_artifact_info']['resource_name'], 'vm_111')
             self.assertIsNotNone(saved_result_dict['saved_artifact_info']['created_date'])
 
     @freeze_time("1984-12-31 11:12:13.4567")


### PR DESCRIPTION
## Description
* rename saved_artifacts_info to saved_artifact_info
* change resource_name attribute on orchestration_save to return the virtual machine name instead of vcenter name

## Related Stories
#749 

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/765)
<!-- Reviewable:end -->
