### PR TITLE
fixing empty output when first snapshhot under a VM

### DIFF
--- a/package/cloudshell/cp/vcenter/commands/save_snapshot.py
+++ b/package/cloudshell/cp/vcenter/commands/save_snapshot.py
@@ -60,5 +60,5 @@ class SaveSnapshotCommand:
     def _get_snapshot_name_to_be_created(snapshot_name, vm):
         current_snapshot_name = SnapshotRetriever.get_current_snapshot_name(vm)
         if not current_snapshot_name:
-            return ''
+            return snapshot_name
         return SnapshotRetriever.combine(current_snapshot_name, snapshot_name)


### PR DESCRIPTION
Fixing empty output when first snapshhot under a VM

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/770)
<!-- Reviewable:end -->
