### PR TITLE
Removed quotes from the description of the 'vCenter Image Arguments' a…

### DIFF
--- a/vCenterShellPackage/DataModel/datamodel.xml
+++ b/vCenterShellPackage/DataModel/datamodel.xml
@@ -6,7 +6,7 @@
         <ns0:Rule Name="Setting" />
       </ns0:Rules>
     </ns0:AttributeInfo>
-    <ns0:AttributeInfo DefaultValue="" Description="Customized properties of the image separated by ','. Example for OVF: --allowExtraConfig, --prop:Hostname=ASAvtest, --prop:HARole=Standalone, --prop:SSHEnable=True, --prop:DHCP=True, --net:Management0-0='Office LAN 41', --net:GigabitEthernet0-0='VLAN_access_101'" IsReadOnly="false" Name="vCenter Image Arguments" Type="String">
+    <ns0:AttributeInfo DefaultValue="" Description="Customized properties of the image separated by comma ( , ). Example for OVF: --allowExtraConfig, --prop:Hostname=ASAvtest, --prop:HARole=Standalone, --prop:SSHEnable=True, --prop:DHCP=True, --net:Management0-0=Office LAN 41, --net:GigabitEthernet0-0=VLAN access 101" IsReadOnly="false" Name="vCenter Image Arguments" Type="String">
       <ns0:Rules>
         <ns0:Rule Name="Configuration" />
         <ns0:Rule Name="Setting" />


### PR DESCRIPTION
## Description
Removed quotes from the description of the 'vCenter Image Arguments' attribute and cleaned-up the desctiption

## Related Stories
#788 

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/793)
<!-- Reviewable:end -->
