### PR TITLE
fix bug #274 Delete vm only command completed with output:"null"

### DIFF
--- a/package/cloudshell/cp/vcenter/common/utilites/command_result.py
+++ b/package/cloudshell/cp/vcenter/common/utilites/command_result.py
@@ -22,6 +22,10 @@ def set_command_result(result, unpicklable=False):
     :param unpicklable: If True adds JSON can be deserialized as real object.
                         When False will be deserialized as dictionary
     """
+    # we do not need to serialize an empty response from the vCenter
+    if result is None:
+        return
+
     json = jsonpickle.encode(result, unpicklable=unpicklable)
     result_for_output = str(json)
     print result_for_output


### PR DESCRIPTION
## Description
- Don't serialize response command if response is None

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/798)
<!-- Reviewable:end -->
