### PR TITLE
task #722 ability to turn promiscuous mode on off

### DIFF
--- a/integration/integration_commands/integration_test_connect.py
+++ b/integration/integration_commands/integration_test_connect.py
@@ -46,7 +46,7 @@ class VirtualSwitchToMachineCommandIntegrationTest(TestCase):
         vm = py_vmomi_service.find_vm_by_name(si, 'QualiSB/Raz', '2')
 
         # Act
-        connector.connect_by_mapping(si, vm, [mapping], None, [])
+        connector.connect_by_mapping(si, vm, [mapping], None, [], Mock(), 'True')
 
         pass
 
@@ -77,7 +77,7 @@ class VirtualSwitchToMachineCommandIntegrationTest(TestCase):
 
         command = VirtualSwitchConnectCommand(py_vmomi_service, connector, name_gen, vlan_spec, range_fac, Mock())
 
-        command.connect_to_networks(si, vm_uuid, [mapping], 'QualiSB/anetwork', [])
+        command.connect_to_networks(si, vm_uuid, [mapping], 'QualiSB/anetwork', [], 'True')
 
     def test_integration(self):
         self.integration_test_connect_A()

--- a/package/cloudshell/cp/vcenter/commands/connect_dvswitch.py
+++ b/package/cloudshell/cp/vcenter/commands/connect_dvswitch.py
@@ -22,7 +22,7 @@ class VirtualSwitchConnectCommand:
         self.vlan_id_range_parser = vlan_id_range_parser
 
     def connect_to_networks(self, si, logger, vm_uuid, vm_network_mappings, default_network_name,
-                            reserved_networks, dv_switch_name):
+                            reserved_networks, dv_switch_name, promiscuous_mode):
         """
         Connect VM to Network
         :param si: VmWare Service Instance - defined connection to vCenter
@@ -32,6 +32,7 @@ class VirtualSwitchConnectCommand:
         :param default_network_name: <str> Full Network name - likes 'DataCenterName/NetworkName'
         :param reserved_networks:
         :param dv_switch_name: <str> Default dvSwitch name
+        :param promiscuous_mode <str> 'True' or 'False' turn on/off promiscuous mode for the port group
         :return: None
         """
         vm = self.pv_service.find_by_uuid(si, vm_uuid)
@@ -47,7 +48,7 @@ class VirtualSwitchConnectCommand:
         mappings = self._prepare_mappings(dv_switch_name=dv_switch_name, vm_network_mappings=vm_network_mappings)
 
         updated_mappings = self.virtual_switch_to_machine_connector.connect_by_mapping(
-            si, vm, mappings, default_network_instance, reserved_networks, logger)
+            si, vm, mappings, default_network_instance, reserved_networks, logger, promiscuous_mode)
 
         connection_results = []
         for updated_mapping in updated_mappings:

--- a/package/cloudshell/cp/vcenter/commands/connect_orchestrator.py
+++ b/package/cloudshell/cp/vcenter/commands/connect_orchestrator.py
@@ -210,13 +210,15 @@ class ConnectionCommandOrchestrator(object):
             self.logger.debug('connecting vm({0}) with the mappings'.format(vm_uuid,
                                                                             jsonpickle.encode(action_mappings,
                                                                                               unpicklable=False)))
-            connection_results = self.connector.connect_to_networks(si=si,
-                                                                    logger=logger,
-                                                                    vm_uuid=vm_uuid,
-                                                                    vm_network_mappings=action_mappings.set_mapping,
-                                                                    default_network_name=self.default_network,
-                                                                    reserved_networks=self.reserved_networks,
-                                                                    dv_switch_name=self.dv_switch_name)
+            connection_results = self.connector.connect_to_networks(
+                si=si,
+                logger=logger,
+                vm_uuid=vm_uuid,
+                vm_network_mappings=action_mappings.set_mapping,
+                default_network_name=self.default_network,
+                reserved_networks=self.reserved_networks,
+                dv_switch_name=self.dv_switch_name,
+                promiscuous_mode=self.vcenter_data_model.promiscuous_mode)
 
             connection_res_map = self._prepare_connection_results_for_extraction(connection_results)
             act_by_mode_by_vlan = self._group_action_by_vlan_id(set_vlan_actions)

--- a/package/cloudshell/cp/vcenter/models/VMwarevCenterResourceModel.py
+++ b/package/cloudshell/cp/vcenter/models/VMwarevCenterResourceModel.py
@@ -13,3 +13,4 @@ class VMwarevCenterResourceModel(object):
         self.execution_server_selector = '' 
         self.reserved_networks = ''
         self.default_datacenter = ''
+        self.promiscuous_mode = ''

--- a/package/cloudshell/cp/vcenter/vm/dvswitch_connector.py
+++ b/package/cloudshell/cp/vcenter/vm/dvswitch_connector.py
@@ -39,7 +39,7 @@ class VirtualSwitchToMachineConnector(object):
         self.dv_port_group_creator = dv_port_group_creator
         self.virtual_machine_port_group_configurer = virtual_machine_port_group_configurer
 
-    def connect_by_mapping(self, si, vm, mapping, default_network, reserved_networks, logger):
+    def connect_by_mapping(self, si, vm, mapping, default_network, reserved_networks, logger, promiscuous_mode):
         """
         gets the mapping to the vnics and connects it to the vm
         :param default_network:
@@ -48,6 +48,7 @@ class VirtualSwitchToMachineConnector(object):
         :param mapping: [VmNetworkMapping]
         :param reserved_networks:
         :param logger:
+        :param promiscuous_mode <str> 'True' or 'False' turn on/off promiscuous mode for the port group
         """
         request_mapping = []
 
@@ -62,7 +63,8 @@ class VirtualSwitchToMachineConnector(object):
                                                                        network_map.dv_switch_path,
                                                                        network_map.vlan_id,
                                                                        network_map.vlan_spec,
-                                                                       logger=logger)
+                                                                       logger,
+                                                                       promiscuous_mode)
 
             request_mapping.append(ConnectRequest(network_map.vnic_name, network))
 

--- a/package/cloudshell/tests/test_commands/test_connect_orchestrator.py
+++ b/package/cloudshell/tests/test_commands/test_connect_orchestrator.py
@@ -22,6 +22,7 @@ class TestCommandOrchestrator(TestCase):
         self.vc_data_model.default_network = 'Anetwork'
         self.vc_data_model.default_datacenter = 'datacenter'
         self.vc_data_model.holding_network = 'Holding Network'
+        self.vc_data_model.promiscuous_mode = 'True'
 
         self.si = Mock()
 
@@ -39,6 +40,7 @@ class TestCommandOrchestrator(TestCase):
         vc_data_model.default_network = 'Anetwork'
         vc_data_model.default_datacenter = 'datacenter'
         vc_data_model.holding_network = 'Holding Network'
+        self.vc_data_model.promiscuous_mode = 'True'
 
         request, expected = self._get_missing_dv_switch_params()
         results = self.ConnectionCommandOrchestrator.connect_bulk(si=self.si,

--- a/package/cloudshell/tests/test_commands/test_connect_vm.py
+++ b/package/cloudshell/tests/test_commands/test_connect_vm.py
@@ -49,20 +49,22 @@ class TestVirtualSwitchToMachineDisconnectCommand(TestCase):
         mapping.vlan_spec = 'trunc'
         mapping.dv_port_name = 'port_name'
         mapping.network = Mock()
+        logger = Mock()
 
         # act
         connect_results = connect_command.connect_to_networks(si=self.si,
-                                                              logger=Mock(),
+                                                              logger=logger,
                                                               vm_uuid=self.vm_uuid,
                                                               vm_network_mappings=[mapping],
                                                               default_network_name='default_network',
                                                               reserved_networks=[],
-                                                              dv_switch_name='')
+                                                              dv_switch_name='',
+                                                              promiscuous_mode='True')
 
         # assert
         self.assertTrue(self.vlan_id_range_parser.parse_vlan_id.called_with(self.vlan_id))
         self.assertTrue(
             self.dv_port_name_gen.generate_port_group_name.called_with(self.vlan_id, self.vlan_spec_factory))
         self.assertTrue(self.vlan_spec_factory.get_vlan_spec.called_with(self.spec_type))
-        self.assertTrue(self.dv_connector.connect_by_mapping.called_with(self.si, self.vm, [mapping]))
+        self.assertTrue(self.dv_connector.connect_by_mapping.called_with(self.si, self.vm, [mapping], logger, 'True'))
         self.assertEqual(connect_results[0].mac_address, 'AA-BB')

--- a/package/cloudshell/tests/test_common/test_vcenter/test_vcenter_data_model_retriever.py
+++ b/package/cloudshell/tests/test_common/test_vcenter/test_vcenter_data_model_retriever.py
@@ -28,7 +28,8 @@ class TestVCenterDataModelRetriever(unittest.TestCase):
                                    'ovf_tool_path': '',
                                    'execution_server_selector': '',
                                    'reserved_networks': '',
-                                   'default_datacenter': ''}
+                                   'default_datacenter': '',
+                                   'promiscuous_mode': ''}
 
         api.GetResourceDetails = Mock(return_value=vcenter_resource)
 
@@ -57,7 +58,8 @@ class TestVCenterDataModelRetriever(unittest.TestCase):
                                    'ovf_tool_path': '',
                                    'execution_server_selector': '',
                                    'reserved_networks': '',
-                                   'default_datacenter': ''}
+                                   'default_datacenter': '',
+                                   'promiscuous_mode': ''}
 
         api.GetResourceDetails = Mock(return_value=vcenter_resource)
 

--- a/package/cloudshell/tests/test_network/test_dvswitch/test_connector.py
+++ b/package/cloudshell/tests/test_network/test_dvswitch/test_connector.py
@@ -85,12 +85,12 @@ class TestVirtualSwitchToMachineConnector(TestCase):
         self.connector.virtual_machine_port_group_configurer.connect_by_mapping = Mock(return_value="OK")
         self.connector.connect_and_get_vm = Mock(return_value=(1, 1,))
 
-        res = self.connector.connect_by_mapping(self.si, self.vm, [], 'default_network', [], logger=Mock())
+        res = self.connector.connect_by_mapping(self.si, self.vm, [], 'default_network', [], Mock(), 'True')
         self.assertEqual(res, 'OK')
-        res = self.connector.connect_by_mapping(self.si, self.vm, [], None, [], logger=Mock())
+        res = self.connector.connect_by_mapping(self.si, self.vm, [], None, [], Mock(), 'True')
         self.assertEqual(res, 'OK')
 
-        res = self.connector.connect_by_mapping(self.si, self.vm, mapp, 'default_network', [], logger=Mock())
+        res = self.connector.connect_by_mapping(self.si, self.vm, mapp, 'default_network', [], Mock(), 'True')
         self.assertEqual(res, 'OK')
-        res = self.connector.connect_by_mapping(self.si, self.vm, mapp, None, [], logger=Mock())
+        res = self.connector.connect_by_mapping(self.si, self.vm, mapp, None, [], Mock(), 'True')
         self.assertEqual(res, 'OK')

--- a/package/cloudshell/tests/test_network/test_dvswitch/test_creator.py
+++ b/package/cloudshell/tests/test_network/test_dvswitch/test_creator.py
@@ -38,7 +38,8 @@ class TestDvPortGroupCreator(TestCase):
                                                     create_autospec(spec=vim.ServiceInstance),
                                                     spec=None,
                                                     vlan_id=1001,
-                                                    logger=Mock())
+                                                    logger=Mock(),
+                                                    promiscuous_mode="True")
 
         # Assert
         self.assertTrue(dv_port_group_creator.dv_port_group_create_task.called)
@@ -59,6 +60,7 @@ class TestDvPortGroupCreator(TestCase):
                                                         spec=spec,
                                                         vlan_id=1001,
                                                         logger=Mock(),
+                                                        promiscuous_mode="True",
                                                         num_ports=32)
 
         # assert

--- a/package/cloudshell/tests/test_vm/test_dvswitch_connector.py
+++ b/package/cloudshell/tests/test_vm/test_dvswitch_connector.py
@@ -43,7 +43,8 @@ class TestVirtualSwitchToMachineConnector(TestCase):
                                                                mapping=[network_map],
                                                                default_network=Mock(spec=vim.Network),
                                                                reserved_networks=[],
-                                                               logger=Mock())
+                                                               logger=Mock(),
+                                                               promiscuous_mode='True')
 
     def integrationtest(self):
         resource_connection_details_retriever = Mock()

--- a/vCenterShellPackage/Configuration/shellconfig.xml
+++ b/vCenterShellPackage/Configuration/shellconfig.xml
@@ -23,6 +23,7 @@ xmlns="http://schemas.qualisystems.com/ResourceManagement/ShellsConfigurationSch
 			<Attribute Name="OVF Tool Path" Value="C:\Program Files (x86)\VMware\VMware Workstation\OVFTool\ovftool.exe" />
 			<Attribute Name="Execution Server Selector" Value="" />
 			<Attribute Name="Reserved Networks" Value="" />
+			<Attribute Name="Promiscuous Mode" Value="True" />
         </Attributes>
     </ResourceTemplate>
 </ResourceTemplates>

--- a/vCenterShellPackage/DataModel/datamodel.xml
+++ b/vCenterShellPackage/DataModel/datamodel.xml
@@ -170,6 +170,12 @@
         <ns0:Rule Name="Setting" />
       </ns0:Rules>
     </ns0:AttributeInfo>
+    <ns0:AttributeInfo DefaultValue="true" Description="If enabled the port groups on the virtual switch will be configured to allow promiscuous mode." IsReadOnly="false" Name="Promiscuous Mode" Type="Boolean">
+      <ns0:Rules>
+        <ns0:Rule Name="Configuration" />
+        <ns0:Rule Name="Setting" />
+      </ns0:Rules>
+    </ns0:AttributeInfo>
   </ns0:Attributes>
   <ns0:ResourceFamilies>
     <ns0:ResourceFamily Description="" IsAdminOnly="true" IsSearchable="true" Name="Cloud Provider">
@@ -220,6 +226,9 @@
             <ns0:AttachedAttribute IsLocal="true" IsOverridable="true" Name="Reserved Networks">
               <ns0:AllowedValues />
             </ns0:AttachedAttribute>
+            <ns0:AttachedAttribute IsLocal="true" IsOverridable="true" Name="Promiscuous Mode">
+              <ns0:AllowedValues />
+            </ns0:AttachedAttribute>
           </ns0:AttachedAttributes>
           <ns0:AttributeValues>
             <ns0:AttributeValue Name="Reserved Networks" Value="" />
@@ -234,6 +243,7 @@
             <ns0:AttributeValue Name="Shutdown Method" Value="hard" />
             <ns0:AttributeValue Name="OVF Tool Path" Value="C:\Program Files (x86)\VMware\VMware Workstation\OVFTool\ovftool.exe" />
             <ns0:AttributeValue Name="Execution Server Selector" Value="" />
+            <ns0:AttributeValue Name="Promiscuous Mode" Value="true" />
           </ns0:AttributeValues>
           <ns0:ParentModels />
           <ns0:Drivers>


### PR DESCRIPTION
## Description
- add "promiscuous_mode" attribute to the vCenter model
- use "promiscuous_mode" for enable/disable promiscuous mode for the newly created port groups

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/800)
<!-- Reviewable:end -->
