### PR TITLE
Task 30 Refactor cloud provider attribute "VCenter Name" into "cloudP…

### DIFF
--- a/deployment_drivers/deploy_clone_from_vm/driver.py
+++ b/deployment_drivers/deploy_clone_from_vm/driver.py
@@ -31,12 +31,21 @@ class DeployCloneFromVMDriver(ResourceDriverInterface):
                                              context.connectivity.admin_auth_token,
                                              context.reservation.domain)
 
+        app_request = jsonpickle.decode(context.resource.app_context.app_request_json)
+
+        if not Name:
+            Name = app_request['name']
+
+        # Cloudshell >= v7.2 have no vCenter Name attribute, fill it from the cloudProviderName context attr
+        cloud_provider_name = app_request["deploymentService"].get("cloudProviderName")
+
+        if cloud_provider_name:
+            attrs = self.resource_model_parser.get_resource_attributes(context.resource)
+            attrs["vCenter Name"] = cloud_provider_name
+
         vcenter_template_resource_model = \
             self.resource_model_parser.convert_to_resource_model(context.resource,
                                                                  vCenterCloneVMFromVMResourceModel)
-
-        if not Name:
-            Name = jsonpickle.decode(context.resource.app_context.app_request_json)['name']
 
         deploy_from_template_details = DeployFromTemplateDetails(vcenter_template_resource_model, Name)
 

--- a/deployment_drivers/deploy_from_linked_clone/driver.py
+++ b/deployment_drivers/deploy_from_linked_clone/driver.py
@@ -31,12 +31,21 @@ class DeployCloneFromVMDriver(ResourceDriverInterface):
                                              context.connectivity.admin_auth_token,
                                              context.reservation.domain)
 
+        app_request = jsonpickle.decode(context.resource.app_context.app_request_json)
+
+        if not Name:
+            Name = app_request['name']
+
+        # Cloudshell >= v7.2 have no vCenter Name attribute, fill it from the cloudProviderName context attr
+        cloud_provider_name = app_request["deploymentService"].get("cloudProviderName")
+
+        if cloud_provider_name:
+            attrs = self.resource_model_parser.get_resource_attributes(context.resource)
+            attrs["vCenter Name"] = cloud_provider_name
+
         vcenter_template_resource_model = \
             self.resource_model_parser.convert_to_resource_model(context.resource,
                                                                  VCenterDeployVMFromLinkedCloneResourceModel)
-
-        if not Name:
-            Name = jsonpickle.decode(context.resource.app_context.app_request_json)['name']
 
         deploy_from_template_details = DeployFromTemplateDetails(vcenter_template_resource_model, Name)
 

--- a/deployment_drivers/deploy_from_template/driver.py
+++ b/deployment_drivers/deploy_from_template/driver.py
@@ -31,12 +31,21 @@ class DeployFromTemplateDriver(ResourceDriverInterface):
                                              context.connectivity.admin_auth_token,
                                              context.reservation.domain)
 
+        app_request = jsonpickle.decode(context.resource.app_context.app_request_json)
+
+        if not Name:
+            Name = app_request['name']
+
+        # Cloudshell >= v7.2 have no vCenter Name attribute, fill it from the cloudProviderName context attr
+        cloud_provider_name = app_request["deploymentService"].get("cloudProviderName")
+
+        if cloud_provider_name:
+            attrs = self.resource_model_parser.get_resource_attributes(context.resource)
+            attrs["vCenter Name"] = cloud_provider_name
+
         vcenter_template_resource_model = \
             self.resource_model_parser.convert_to_resource_model(context.resource,
                                                                  vCenterVMFromTemplateResourceModel)
-
-        if not Name:
-            Name = jsonpickle.decode(context.resource.app_context.app_request_json)['name']
 
         deploy_from_template_details = DeployFromTemplateDetails(vcenter_template_resource_model, Name)
 

--- a/vCenterShellPackage/DataModel/datamodel.xml
+++ b/vCenterShellPackage/DataModel/datamodel.xml
@@ -134,12 +134,6 @@
         <ns0:Rule Name="Setting" />
       </ns0:Rules>
     </ns0:AttributeInfo>
-    <ns0:AttributeInfo DefaultValue="" Description="The vCenter resource name in CloudShell." IsReadOnly="false" Name="vCenter Name" Type="String">
-      <ns0:Rules>
-        <ns0:Rule Name="Configuration" />
-        <ns0:Rule Name="Setting" />
-      </ns0:Rules>
-    </ns0:AttributeInfo>
     <ns0:AttributeInfo DefaultValue="true" Description="Enables the automatic power on of an app following its deployment during reservation Setup." IsReadOnly="false" Name="Auto Power On" Type="Boolean">
       <ns0:Rules>
         <ns0:Rule Name="Configuration" />
@@ -303,9 +297,6 @@
       <ns0:Models>
         <ns0:ResourceModel Description="" Name="vCenter Clone VM From VM" ImagePath="DeploymentTypes-vCenterClone.png" SupportsConcurrentCommands="false">
           <ns0:AttachedAttributes>
-            <ns0:AttachedAttribute IsLocal="true" IsOverridable="true" Name="vCenter Name" UserInput="true">
-              <ns0:AllowedValues />
-            </ns0:AttachedAttribute>
             <ns0:AttachedAttribute IsLocal="true" IsOverridable="true" Name="vCenter VM" UserInput="true">
               <ns0:AllowedValues />
             </ns0:AttachedAttribute>
@@ -344,7 +335,6 @@
             </ns0:AttachedAttribute>
           </ns0:AttachedAttributes>
           <ns0:AttributeValues>
-            <ns0:AttributeValue Name="vCenter Name" Value="VMWare vCenter" />
             <ns0:AttributeValue Name="Auto Power On" Value="True" />
             <ns0:AttributeValue Name="Auto Power Off" Value="True" />
             <ns0:AttributeValue Name="Wait for IP" Value="True" />
@@ -365,9 +355,6 @@
         </ns0:ResourceModel>
         <ns0:ResourceModel Description="" Name="vCenter VM From Template" ImagePath="DeploymentTypes-vCenterTemplate.png" SupportsConcurrentCommands="false">
           <ns0:AttachedAttributes>
-            <ns0:AttachedAttribute IsLocal="true" IsOverridable="true" Name="vCenter Name" UserInput="true">
-              <ns0:AllowedValues />
-            </ns0:AttachedAttribute>
             <ns0:AttachedAttribute IsLocal="true" IsOverridable="true" Name="vCenter Template" UserInput="true">
               <ns0:AllowedValues />
             </ns0:AttachedAttribute>
@@ -406,7 +393,6 @@
             </ns0:AttachedAttribute>
           </ns0:AttachedAttributes>
           <ns0:AttributeValues>
-            <ns0:AttributeValue Name="vCenter Name" Value="VMWare vCenter" />
             <ns0:AttributeValue Name="Auto Power On" Value="True" />
             <ns0:AttributeValue Name="Auto Power Off" Value="True" />
             <ns0:AttributeValue Name="Wait for IP" Value="True" />
@@ -427,9 +413,6 @@
         </ns0:ResourceModel>
         <ns0:ResourceModel Description="" Name="VCenter Deploy VM From Linked Clone" ImagePath="DeploymentTypes-vCenterLinked.png" SupportsConcurrentCommands="false">
           <ns0:AttachedAttributes>
-            <ns0:AttachedAttribute IsLocal="true" IsOverridable="true" Name="vCenter Name" UserInput="true">
-              <ns0:AllowedValues />
-            </ns0:AttachedAttribute>
             <ns0:AttachedAttribute IsLocal="true" IsOverridable="true" Name="vCenter VM" UserInput="true">
               <ns0:AllowedValues />
             </ns0:AttachedAttribute>
@@ -471,7 +454,6 @@
             </ns0:AttachedAttribute>
           </ns0:AttachedAttributes>
           <ns0:AttributeValues>
-            <ns0:AttributeValue Name="vCenter Name" Value="VMware vCenter" />
             <ns0:AttributeValue Name="Auto Power On" Value="True" />
             <ns0:AttributeValue Name="Auto Power Off" Value="True" />
             <ns0:AttributeValue Name="Wait for IP" Value="True" />
@@ -519,9 +501,6 @@
             <ns0:AttachedAttribute IsLocal="true" IsOverridable="true" Name="vCenter Image" UserInput="true">
               <ns0:AllowedValues />
             </ns0:AttachedAttribute>
-            <ns0:AttachedAttribute IsLocal="true" IsOverridable="true" Name="vCenter Name" UserInput="true">
-              <ns0:AllowedValues />
-            </ns0:AttachedAttribute>
             <ns0:AttachedAttribute IsLocal="true" IsOverridable="true" Name="vCenter Image Arguments" UserInput="true">
               <ns0:AllowedValues />
             </ns0:AttachedAttribute>
@@ -550,7 +529,6 @@
             <ns0:AttributeValue Name="IP Regex" Value="" />
             <ns0:AttributeValue Name="VM Resource Pool" Value="" />
             <ns0:AttributeValue Name="vCenter Image" Value="" />
-            <ns0:AttributeValue Name="vCenter Name" Value="" />
             <ns0:AttributeValue Name="vCenter Image Arguments" Value="" />
             <ns0:AttributeValue Name="Refresh IP Timeout" Value="600" />
           </ns0:AttributeValues>


### PR DESCRIPTION
## Description
Use "cloudProviderName" from context instead of "VCenter Name" attribute in all App drivers

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/802)
<!-- Reviewable:end -->
