### PR TITLE
Ticket 29931. Created Vlans are not cleaned up by Teardown script.

### DIFF
--- a/package/cloudshell/cp/vcenter/vm/portgroup_configurer.py
+++ b/package/cloudshell/cp/vcenter/vm/portgroup_configurer.py
@@ -63,9 +63,9 @@ class VirtualMachinePortGroupConfigurer(object):
         self._lock.acquire()
         try:
             for net in networks:
-                try:
-                    nets[net.name] = net
-                    for network in nets.values():
+                nets[net.name] = net
+                for network in nets.values():
+                    try:
                         if self.network_name_gen.is_generated_name(network.name) \
                                 and (not reserved_networks or network.name not in reserved_networks) \
                                 and not network.vm:
@@ -75,10 +75,8 @@ class VirtualMachinePortGroupConfigurer(object):
                                     self.synchronous_task_waiter.wait_for_task(task=task,
                                                                                logger=logger,
                                                                                action_name='Erase dv Port Group')
-                except Exception as e:
-                    logger.debug("Failed to erase network", exc_info=True)
-                    a = e.msg
-                    continue
+                    except Exception:
+                        continue
         finally:
             self._lock.release()
 


### PR DESCRIPTION
Portal: Reservation: Created Vlans are not cleaned up by Teardown script.

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related Stories
List related PRs against other branches:

## Breaking
YES | NO

## Breaking changes
- ### Breaking change description
      Detailed change info 
      Migration steps

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/855)
<!-- Reviewable:end -->
