### PR TITLE
make sure target vm has vnics before trying to apply vlan to it

### DIFF
--- a/package/cloudshell/cp/vcenter/commands/connect_dvswitch.py
+++ b/package/cloudshell/cp/vcenter/commands/connect_dvswitch.py
@@ -1,4 +1,5 @@
 from cloudshell.cp.vcenter.models.ConnectionResult import ConnectionResult
+from cloudshell.cp.vcenter.common.vcenter.vmomi_service import vm_has_no_vnics
 
 
 class VirtualSwitchConnectCommand:
@@ -44,6 +45,9 @@ class VirtualSwitchConnectCommand:
 
         if not default_network_instance:
             raise ValueError('Default Network {0} not found'.format(default_network_name))
+
+        if vm_has_no_vnics(vm):
+            raise ValueError('Trying to connect VM (uuid: {0}) but it has no vNics'.format(vm_uuid))
 
         mappings = self._prepare_mappings(dv_switch_name=dv_switch_name, vm_network_mappings=vm_network_mappings)
 

--- a/package/cloudshell/cp/vcenter/common/vcenter/vmomi_service.py
+++ b/package/cloudshell/cp/vcenter/common/vcenter/vmomi_service.py
@@ -683,3 +683,9 @@ class pyVmomiService:
             if snapshot_header.name == name:
                 return snapshot_header
         return None
+
+
+def vm_has_no_vnics(vm):
+    # Is there any network device on vm
+    return next((False for device in vm.config.hardware.device
+                if isinstance(device, vim.vm.device.VirtualEthernetCard) and hasattr(device, 'macAddress')), True)

--- a/package/cloudshell/cp/vcenter/vm/portgroup_configurer.py
+++ b/package/cloudshell/cp/vcenter/vm/portgroup_configurer.py
@@ -55,6 +55,7 @@ class VirtualMachinePortGroupConfigurer(object):
             self.update_vnic_by_mapping(vm, update_mapping, logger)
             return update_mapping
         except Exception as e:
+            self.erase_network_by_mapping([request.network for request in mapping], reserved_networks, logger)
             logger.exception("Failed to connect VM: {}".format(vm.name))
             raise ValueError('VM: {0} failed with: "{1}"'.format(vm.name, e.message))
 

--- a/package/cloudshell/tests/test_commands/test_command_orchestrator.py
+++ b/package/cloudshell/tests/test_commands/test_command_orchestrator.py
@@ -4,7 +4,8 @@ from freezegun import freeze_time
 import jsonpickle
 from cloudshell.api.cloudshell_api import ResourceInfo
 from cloudshell.cp.vcenter.commands.command_orchestrator import CommandOrchestrator
-from cloudshell.shell.core.driver_context import ResourceRemoteCommandContext, ResourceContextDetails, AppContext
+from cloudshell.shell.core.driver_context import ResourceRemoteCommandContext, ResourceContextDetails
+from cloudshell.shell.core.context import AppContext
 from mock import Mock, create_autospec, patch
 
 RESTORE_SNAPSHOT = 'cloudshell.cp.vcenter.commands.command_orchestrator.CommandOrchestrator.restore_snapshot'

--- a/package/cloudshell/tests/test_commands/test_connect_vm.py
+++ b/package/cloudshell/tests/test_commands/test_connect_vm.py
@@ -12,9 +12,14 @@ class TestVirtualSwitchToMachineDisconnectCommand(TestCase):
         self.vlan_id_gen = 'gen_id'
         self.name_gen = 'gen_name'
         self.spec = Mock()
-        self.vm = Mock()
+        self.vm = Fake()
+        nic = Mock(spec=vim.vm.device.VirtualEthernetCard)
+        nic.macAddress = True
+        self.vm.config = Fake()
+        self.vm.config.hardware=Fake()
+        self.vm.config.hardware.device = [nic]
         self.pv_service = Mock()
-        self.pv_service.find_by_uuid = Mock(self.vm)
+        self.pv_service.find_by_uuid = lambda x, y: self.vm
         self.si = Mock()
         self.vm_uuid = 'uuid'
         self.vlan_id = 100
@@ -68,3 +73,11 @@ class TestVirtualSwitchToMachineDisconnectCommand(TestCase):
         self.assertTrue(self.vlan_spec_factory.get_vlan_spec.called_with(self.spec_type))
         self.assertTrue(self.dv_connector.connect_by_mapping.called_with(self.si, self.vm, [mapping], logger, 'True'))
         self.assertEqual(connect_results[0].mac_address, 'AA-BB')
+
+
+def vm_has_no_vnics():
+    return False
+
+
+class Fake(object):
+    pass


### PR DESCRIPTION
## Description
should fail an attempt to create a vlan for a vm that hs no vnics

## Related Stories
http://team:8080/tfs/Quali-Collection/QualiSystems/_workitems/edit/161406

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/874)
<!-- Reviewable:end -->
