### PR TITLE
added retry in refresh_ip for api calls to cloudshell

### DIFF
--- a/package/cloudshell/cp/vcenter/commands/command_orchestrator.py
+++ b/package/cloudshell/cp/vcenter/commands/command_orchestrator.py
@@ -373,7 +373,8 @@ class CommandOrchestrator(object):
         app_resource_detail.vm_uuid = holder.vmdetails.uid
         app_resource_detail.cloud_provider = context.resource.fullname
         app_resource_detail.fullname = resource.fullname
-        app_resource_detail.vm_custom_params = holder.vmdetails.vmCustomParams
+        if hasattr(holder.vmdetails, 'vmCustomParams'):
+            app_resource_detail.vm_custom_params = holder.vmdetails.vmCustomParams
         return app_resource_detail
 
     def power_on_not_roemote(self, context, vm_uuid, resource_fullname):

--- a/package/cloudshell/cp/vcenter/commands/command_orchestrator.py
+++ b/package/cloudshell/cp/vcenter/commands/command_orchestrator.py
@@ -3,6 +3,7 @@ from datetime import datetime, date
 import jsonpickle
 
 from cloudshell.cp.vcenter.models.DeployFromImageDetails import DeployFromImageDetails
+from cloudshell.shell.core.context import ResourceRemoteCommandContext
 from cloudshell.cp.vcenter.models.OrchestrationSaveResult import OrchestrationSaveResult
 from cloudshell.cp.vcenter.models.OrchestrationSavedArtifactsInfo import OrchestrationSavedArtifactsInfo
 from cloudshell.cp.vcenter.models.OrchestrationSavedArtifact import OrchestrationSavedArtifact
@@ -303,7 +304,7 @@ class CommandOrchestrator(object):
     def refresh_ip(self, context, cancellation_context, ports):
         """
         Refresh IP Command, will refresh the ip of the vm and will update it on the resource
-        :param models.QualiDriverModels.ResourceRemoteCommandContext context: the context the command runs on
+        :param ResourceRemoteCommandContext context: the context the command runs on
         :param cancellation_context:
         :param list[string] ports: the ports of the connection between the remote resource and the local resource, NOT IN USE!!!
         """
@@ -311,8 +312,7 @@ class CommandOrchestrator(object):
         # execute command
         res = self.command_wrapper.execute_command_with_connection(context,
                                                                    self.refresh_ip_command.refresh_ip,
-                                                                   resource_details.vm_uuid,
-                                                                   resource_details.fullname,
+                                                                   resource_details,
                                                                    cancellation_context,
                                                                    context.remote_endpoints[0].app_context.app_request_json)
         return set_command_result(result=res, unpicklable=False)
@@ -373,6 +373,7 @@ class CommandOrchestrator(object):
         app_resource_detail.vm_uuid = holder.vmdetails.uid
         app_resource_detail.cloud_provider = context.resource.fullname
         app_resource_detail.fullname = resource.fullname
+        app_resource_detail.vm_custom_params = holder.vmdetails.vmCustomParams
         return app_resource_detail
 
     def power_on_not_roemote(self, context, vm_uuid, resource_fullname):

--- a/package/cloudshell/cp/vcenter/commands/refresh_ip.py
+++ b/package/cloudshell/cp/vcenter/commands/refresh_ip.py
@@ -1,9 +1,12 @@
 import re
 import time
 
+from retrying import retry
+
 from cloudshell.cp.vcenter.commands.ip_result import IpResult, IpReason
 
 from cloudshell.cp.vcenter.common.vcenter.vm_location import VMLocation
+from cloudshell.cp.vcenter.models.GenericDeployedAppResourceModel import GenericDeployedAppResourceModel
 
 
 class RefreshIpCommand(object):
@@ -19,15 +22,15 @@ class RefreshIpCommand(object):
         if app_request_json == '' or app_request_json is None:
             raise ValueError('This command cannot be executed on a Static VM.')
 
-    def refresh_ip(self, si, logger, session, vcenter_data_model, vm_uuid, resource_name, cancellation_context,app_request_json):
+    def refresh_ip(self, si, logger, session, vcenter_data_model, resource_model, cancellation_context,
+                   app_request_json):
         """
         Refreshes IP address of virtual machine and updates Address property on the resource
 
         :param vim.ServiceInstance si: py_vmomi service instance
         :param logger:
         :param vCenterShell.driver.SecureCloudShellApiSession session: cloudshell session
-        :param str vm_uuid: UUID of Virtual Machine
-        :param str resource_name: Logical resource name to update address property on
+        :param GenericDeployedAppResourceModel resource_model: UUID of Virtual Machine
         :param VMwarevCenterResourceModel vcenter_data_model: the vcenter data model attributes
         :param cancellation_context:
         """
@@ -36,29 +39,34 @@ class RefreshIpCommand(object):
         default_network = VMLocation.combine(
             [vcenter_data_model.default_datacenter, vcenter_data_model.holding_network])
 
-        resource = session.GetResourceDetails(resource_name)
+        match_function = self.ip_manager.get_ip_match_function(
+            self._get_ip_refresh_ip_regex(resource_model.vm_custom_params))
 
-        match_function = self.ip_manager.get_ip_match_function(self._get_ip_refresh_ip_regex(resource))
+        timeout = self._get_ip_refresh_timeout(resource_model.vm_custom_params)
 
-        timeout = self._get_ip_refresh_timeout(resource)
-
-        vm = self.pyvmomi_service.find_by_uuid(si, vm_uuid)
+        vm = self.pyvmomi_service.find_by_uuid(si, resource_model.vm_uuid)
 
         ip_res = self.ip_manager.get_ip(vm, default_network, match_function, cancellation_context, timeout, logger)
 
         if ip_res.reason == IpReason.Timeout:
             raise ValueError('IP address of VM \'{0}\' could not be obtained during {1} seconds'
-                             .format(resource_name, timeout))
+                             .format(resource_model.fullname, timeout))
 
         if ip_res.reason == IpReason.Success:
-            session.UpdateResourceAddress(resource_name, ip_res.ip_address)
+            self._update_resource_address_with_retry(session=session,
+                                                     resource_name=resource_model.fullname,
+                                                     ip_address=ip_res.ip_address)
 
             return ip_res.ip_address
 
+    @retry(stop_max_attempt_number=5, wait_fixed=1000)
+    def _update_resource_address_with_retry(self, session, resource_name, ip_address):
+        session.UpdateResourceAddress(resource_name, ip_address)
+
     @staticmethod
-    def _get_ip_refresh_timeout(resource):
+    def _get_ip_refresh_timeout(custom_params):
         timeout = RefreshIpCommand._get_custom_param(
-            resource=resource,
+            custom_params=custom_params,
             custom_param_name='refresh_ip_timeout')
 
         if not timeout:
@@ -67,21 +75,18 @@ class RefreshIpCommand(object):
         return float(timeout)
 
     @staticmethod
-    def _get_ip_refresh_ip_regex(resource):
+    def _get_ip_refresh_ip_regex(custom_params):
         return RefreshIpCommand._get_custom_param(
-            resource=resource,
+            custom_params=custom_params,
             custom_param_name='ip_regex')
 
     @staticmethod
-    def _get_custom_param(resource, custom_param_name):
-        custom_param_values = []
-        vm_details = resource.VmDetails
-        if vm_details and hasattr(vm_details, 'VmCustomParams') and vm_details.VmCustomParams:
-            custom_params = vm_details.VmCustomParams
-            params = custom_params if isinstance(custom_params, list) else [custom_params]
-            custom_param_values = [custom_param.Value for custom_param
-                                   in params
-                                   if custom_param.Name == custom_param_name]
+    def _get_custom_param(custom_params, custom_param_name):
+        if not custom_params:
+            return None
+
+        custom_param_values = [custom_param.value for custom_param in custom_params
+                               if custom_param.name == custom_param_name]
 
         if custom_param_values:
             return custom_param_values[0]

--- a/package/cloudshell/cp/vcenter/models/GenericDeployedAppResourceModel.py
+++ b/package/cloudshell/cp/vcenter/models/GenericDeployedAppResourceModel.py
@@ -2,3 +2,5 @@ class GenericDeployedAppResourceModel(object):
     def __init__(self):
         self.vm_uuid = ''
         self.cloud_provider = ''
+        self.fullname = ''
+        self.vm_custom_params = None

--- a/package/cloudshell/tests/test_commands/test_refresh_ip.py
+++ b/package/cloudshell/tests/test_commands/test_refresh_ip.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from cloudshell.api.cloudshell_api import ResourceInfoVmDetails, ResourceInfo, VmCustomParam
+from cloudshell.cp.vcenter.models import GenericDeployedAppResourceModel
 from mock import Mock, create_autospec
 from cloudshell.cp.vcenter.commands.refresh_ip import RefreshIpCommand
 from cloudshell.cp.vcenter.models.VMwarevCenterResourceModel import VMwarevCenterResourceModel
@@ -30,18 +31,15 @@ class TestRefreshIpCommand(TestCase):
         ip_regex = self._create_custom_param('ip_regex', '192\.168\..*')
         refresh_ip_timeout = self._create_custom_param('refresh_ip_timeout', '10')
 
-        resource_instance = create_autospec(ResourceInfo)
-        resource_instance.ResourceModelName = 'Generic Deployed App'
-        resource_instance.ResourceAttributes = {'vm_uuis': '123',
-                                                'cloud_provider': 'vCenter'
-                                                }
-        resource_instance.VmDetails = create_autospec(ResourceInfoVmDetails)
-        resource_instance.VmDetails.VmCustomParams = [ip_regex, refresh_ip_timeout]
+        resource_model = create_autospec(GenericDeployedAppResourceModel)
+        resource_model.fullname = 'Generic Deployed App'
+        resource_model.vm_uuid = '123',
+        resource_model.cloud_provider = 'vCenter'
+        resource_model.vm_custom_params = [ip_regex, refresh_ip_timeout]
 
         refresh_ip_command = RefreshIpCommand(pyvmomi_service, ResourceModelParser(), Mock())
         session = Mock()
         session.UpdateResourceAddress = Mock(return_value=True)
-        session.GetResourceDetails = Mock(return_value=resource_instance)
         si = Mock()
 
         center_resource_model = VMwarevCenterResourceModel()
@@ -53,8 +51,7 @@ class TestRefreshIpCommand(TestCase):
         refresh_ip_command.refresh_ip(si=si,
                                       session=session,
                                       vcenter_data_model=center_resource_model,
-                                      vm_uuid='machine1',
-                                      resource_name='default_network',
+                                      resource_model=resource_model,
                                       cancellation_context=cancellation_context,
                                       logger=Mock(),
                                       app_request_json=Mock())
@@ -63,11 +60,9 @@ class TestRefreshIpCommand(TestCase):
         self.assertTrue(session.UpdateResourceAddress.called_with('machine1', '192.168.1.1'))
 
     def _create_custom_param(self, name, value):
-        node = Mock()
-        node.attrib = {'Name': name, 'Value': value}
-        vm_custom_param = VmCustomParam(node, '')
-        vm_custom_param.Name = name
-        vm_custom_param.Value = value
+        vm_custom_param = Mock()
+        vm_custom_param.name = name
+        vm_custom_param.value = value
         return vm_custom_param
 
     def test_refresh_ip_choose_ipv4(self):
@@ -92,18 +87,16 @@ class TestRefreshIpCommand(TestCase):
         ip_regex = self._create_custom_param('ip_regex', '')
         refresh_ip_timeout = self._create_custom_param('refresh_ip_timeout', '10')
 
-        resource_instance = create_autospec(ResourceInfo)
-        resource_instance.ResourceModelName = 'Generic Deployed App'
-        resource_instance.ResourceAttributes = {'vm_uuis': '123',
-                                                'cloud_provider': 'vCenter'
-                                                }
-        resource_instance.VmDetails = create_autospec(ResourceInfoVmDetails)
-        resource_instance.VmDetails.VmCustomParams = [ip_regex, refresh_ip_timeout]
+        resource_model = create_autospec(GenericDeployedAppResourceModel)
+        resource_model.fullname = 'Generic Deployed App'
+        resource_model.vm_uuid = '123',
+        resource_model.cloud_provider = 'vCenter'
+        resource_model.vm_custom_params = [ip_regex, refresh_ip_timeout]
 
         refresh_ip_command = RefreshIpCommand(pyvmomi_service, ResourceModelParser(), Mock())
         session = Mock()
         session.UpdateResourceAddress = Mock(return_value=True)
-        session.GetResourceDetails = Mock(return_value=resource_instance)
+        session.GetResourceDetails = Mock(return_value=resource_model)
         si = Mock()
 
         center_resource_model = VMwarevCenterResourceModel()
@@ -116,8 +109,7 @@ class TestRefreshIpCommand(TestCase):
             si=si,
             session=session,
             vcenter_data_model=center_resource_model,
-            vm_uuid='machine1',
-            resource_name='default_network',
+            resource_model=resource_model,
             cancellation_context=cancellation_context,
             logger=Mock(),
             app_request_json=Mock())
@@ -147,18 +139,16 @@ class TestRefreshIpCommand(TestCase):
         ip_regex = self._create_custom_param('ip_regex', '192\.168\..*')
         refresh_ip_timeout = self._create_custom_param('refresh_ip_timeout', '10')
 
-        resource_instance = create_autospec(ResourceInfo)
-        resource_instance.ResourceModelName = 'Generic Deployed App'
-        resource_instance.ResourceAttributes = {'vm_uuis': '123',
-                                                'cloud_provider': 'vCenter'
-                                                }
-        resource_instance.VmDetails = create_autospec(ResourceInfoVmDetails)
-        resource_instance.VmDetails.VmCustomParams = [ip_regex, refresh_ip_timeout]
+        resource_model = create_autospec(GenericDeployedAppResourceModel)
+        resource_model.fullname = 'Generic Deployed App'
+        resource_model.vm_uuid = '123',
+        resource_model.cloud_provider = 'vCenter'
+        resource_model.vm_custom_params = [ip_regex, refresh_ip_timeout]
 
         refresh_ip_command = RefreshIpCommand(pyvmomi_service, ResourceModelParser(), Mock())
         session = Mock()
         session.UpdateResourceAddress = Mock(return_value=True)
-        session.GetResourceDetails = Mock(return_value=resource_instance)
+        session.GetResourceDetails = Mock(return_value=resource_model)
         si = Mock()
 
         center_resource_model = VMwarevCenterResourceModel()
@@ -171,8 +161,7 @@ class TestRefreshIpCommand(TestCase):
             si=si,
             session=session,
             vcenter_data_model=center_resource_model,
-            vm_uuid='machine1',
-            resource_name='default_network',
+            resource_model=resource_model,
             cancellation_context=cancellation_context,
             logger=Mock(),
             app_request_json=Mock())
@@ -184,5 +173,5 @@ class TestRefreshIpCommand(TestCase):
         # Act
         refresh_ip_command = RefreshIpCommand(Mock(), Mock(), Mock())
         # assert
-        self.assertRaises(ValueError, refresh_ip_command.refresh_ip, Mock(), Mock(), Mock(), Mock(), Mock(), Mock(),
+        self.assertRaises(ValueError, refresh_ip_command.refresh_ip, Mock(), Mock(), Mock(), Mock(), Mock(),
                           Mock(), None)

--- a/package/cloudshell/tests/tests_pycommon/test_resourceModelParser.py
+++ b/package/cloudshell/tests/tests_pycommon/test_resourceModelParser.py
@@ -69,12 +69,3 @@ class TestResourceModelParser(TestCase):
         resource_model_parser = ResourceModelParser()
 
         self.assertRaises(ValueError, resource_model_parser.convert_to_resource_model, {}, None)
-
-    def test_parse_response_info(self):
-        resource_model_parser = ResourceModelParser()
-
-        attributes = {'VM_UUID': '422258cd-8b76-e375-8c3b-8e1bf86a4713', 'Cloud Provider':'vCenter' }
-
-        resource_model = resource_model_parser.convert_to_resource_model(attributes, GenericDeployedAppResourceModel)
-
-        self.assertEqual(resource_model.vm_uuid, '422258cd-8b76-e375-8c3b-8e1bf86a4713')

--- a/package/test_requirements.txt
+++ b/package/test_requirements.txt
@@ -1,1 +1,3 @@
 nose
+mock
+freezegun


### PR DESCRIPTION
## Description
1) added retry in refresh_ip for api calls to cloudshell
(cherry picked from commit 1b0ca4af0ed9d4277c716e3aa4aa775a28122727)
2) removed redundant call to GetResourceDetails in refresh ip

## Breaking
NO

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/893)
<!-- Reviewable:end -->
