### PR TITLE
Noam enum34 cryptography fix

### DIFF
--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -4,5 +4,5 @@ cloudshell-automation-api>=8.3.0.0,<8.3.1.0
 cloudshell-shell-core>=3.1.0,<3.2.0
 pyvmomi==6.5.0
 jsonpickle==0.9.3
-enum==0.4.6
+enum34
 retrying==1.3.3

--- a/package/requirements.txt
+++ b/package/requirements.txt
@@ -4,5 +4,5 @@ cloudshell-automation-api>=8.3.0.0,<8.3.1.0
 cloudshell-shell-core>=3.1.0,<3.2.0
 pyvmomi==6.5.0
 jsonpickle==0.9.3
-enum34
+enum34==1.1.6
 retrying==1.3.3


### PR DESCRIPTION
cryptography and vcenter shell are running from the same environment 

cryptography requests enum34.
vcenter shell  requests enum.

cryptography has  a module name.py that have this code:

from enum import Enum

class _ASN1Type(Enum):
    UTF8String = 12

_ASN1_TYPE_TO_ENUM = dict((i.value, i) for i in _ASN1Type)

this code expects Enum to be enum34 package , if enum lib is also installed it will throw  "TypeError: 'type' object is not iterable"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/915)
<!-- Reviewable:end -->
