### PR TITLE
fixing bug 167905

### DIFF
--- a/package/cloudshell/cp/vcenter/common/utilites/savers/linked_clone_artifact_saver.py
+++ b/package/cloudshell/cp/vcenter/common/utilites/savers/linked_clone_artifact_saver.py
@@ -13,9 +13,6 @@ from cloudshell.cp.vcenter.vm.vcenter_details_factory import VCenterDetailsFacto
 
 
 SAVED_SANDBOXES = "Saved Sandboxes"
-COPY_TO_SAVED_ATTRIBUTES = ['VM Cluster', 'VM Storage, VM Resource Pool', 'VM Location', 'Auto Power On', 'Auto Power Off',
-                            'Wait for IP', 'Auto Delete', 'Autoload', 'IP Regex', 'Refresh IP']
-
 
 class LinkedCloneArtifactHandler(object):
     def __init__(self, pv_service, vcenter_data_model, si, logger, deployer, reservation_id,
@@ -81,13 +78,8 @@ class LinkedCloneArtifactHandler(object):
 
         vcenter_vm_path = self._get_saved_app_result_vcenter_vm_path(data_holder, result)
 
-        original_deployment_attributes = save_action.actionParams.deploymentPathAttributes
-
         saved_entity_attributes = [Attribute('vCenter VM', vcenter_vm_path),
                                    Attribute('vCenter VM Snapshot', self.SNAPSHOT_NAME)]
-
-        saved_entity_attributes.extend([Attribute(k, v) for k, v in original_deployment_attributes.iteritems()
-                                        if k in COPY_TO_SAVED_ATTRIBUTES])
 
         self.logger.info('[{1}] Save Action using source type: Linked Clone Successful. Saved Sandbox App with snapshot created: {0}'.format(result.vmName, thread_id))
 

--- a/package/cloudshell/cp/vcenter/vm/ip_manager.py
+++ b/package/cloudshell/cp/vcenter/vm/ip_manager.py
@@ -34,8 +34,14 @@ class VMIPManager(object):
 
     @staticmethod
     def get_ip_match_function(ip_regex=None):
-        ip_regex = ip_regex or '.*'
-        return re.compile(ip_regex).match
+
+        if(not ip_regex):
+            return  re.compile('.*').match
+
+        try:
+            return re.compile(ip_regex).match
+        except Exception as e:
+            raise ValueError('Invalid IP REGEX : {0} '.format(ip_regex))
 
     def _obtain_ip(self, vm, default_network, match_function, logger):
         ip = None


### PR DESCRIPTION
Before:  attributes from original deployment path  were returned from shell and override saving path atts.
After: merging attributes from original deployment path with saving path in SERVER so no need to return unchanged attributes from shell.

also made a normal error message when IP regex is invalid instead of the horrific 'nothing to repeat' python message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/954)
<!-- Reviewable:end -->
