### PR TITLE
verifying that there are storage devices under the cluster

### DIFF
--- a/package/cloudshell/cp/vcenter/common/vcenter/vmomi_service.py
+++ b/package/cloudshell/cp/vcenter/common/vcenter/vmomi_service.py
@@ -524,9 +524,13 @@ class pyVmomiService:
                                      [self.vim.StoragePod],
                                      name)
             if datastore:
-                datastore = sorted(datastore.childEntity,
-                                   key=lambda data: data.summary.freeSpace,
-                                   reverse=True)[0]
+                storage_by_freespace = sorted(datastore.childEntity,
+                                              key=lambda data: data.summary.freeSpace,
+                                              reverse=True)
+                if len(storage_by_freespace) > 0:
+                    datastore = storage_by_freespace[0]
+                else:
+                    raise ValueError('There are no available storage devices under the provided cluster "{0}"'.format(clone_params.datastore_name))
 
         if not datastore:
             raise ValueError('Could not find Datastore: "{0}"'.format(clone_params.datastore_name))


### PR DESCRIPTION
when getting the list of storage devices, to select the one with the freest space, make sure you get any before selecting the first one - otherwise an "list index out of range" happens.

## Breaking
NO

Note: another validation can be added to the auto-load to notice this issue sooner.


