### PR TITLE
autodiscovery should now correctly identify resource pool when it is …

### DIFF
--- a/package/cloudshell/cp/vcenter/common/vcenter/vmomi_service.py
+++ b/package/cloudshell/cp/vcenter/common/vcenter/vmomi_service.py
@@ -448,7 +448,7 @@ class pyVmomiService:
 
         snapshot = self._get_snapshot(clone_params, template)
 
-        resource_pool, host = self._get_resource_pool(datacenter.name, clone_params)
+        resource_pool, host = self.get_resource_pool(datacenter.name, clone_params)
 
         if not resource_pool and not host:
             raise ValueError('The specifed host, cluster or resource pool could not be found')
@@ -539,7 +539,7 @@ class pyVmomiService:
             raise ValueError('Could not find Datastore: "{0}"'.format(clone_params.datastore_name))
         return datastore
 
-    def _get_resource_pool(self, datacenter_name, clone_params):
+    def get_resource_pool(self, datacenter_name, clone_params):
 
         obj_name = '{0}/{1}/{2}'.format(datacenter_name,
                                         clone_params.cluster_name,

--- a/package/cloudshell/tests/test_common/test_vcenter/test_vmomi_service.py
+++ b/package/cloudshell/tests/test_common/test_vcenter/test_vmomi_service.py
@@ -69,7 +69,7 @@ class TestVmomiService(unittest.TestCase):
         pv_service.get_obj = Mock()
         pv_service.get_folder = Mock(return_value=datacenter)
         pv_service._get_datastore = Mock(return_value=Mock(spec=vim.Datastore))
-        pv_service._get_resource_pool = Mock(return_value=(Mock(spec=vim.ResourcePool), None))
+        pv_service.get_resource_pool = Mock(return_value=(Mock(spec=vim.ResourcePool), None))
 
         params = pv_service.CloneVmParameters(si=si,
                                               template_name='my_temp',
@@ -111,7 +111,7 @@ class TestVmomiService(unittest.TestCase):
         pv_service.get_obj = Mock()
         pv_service.get_folder = Mock(return_value=datacenter)
         pv_service._get_datastore = Mock(return_value=Mock(spec=vim.Datastore))
-        pv_service._get_resource_pool = Mock(return_value=(Mock(spec=vim.ResourcePool), None))
+        pv_service.get_resource_pool = Mock(return_value=(Mock(spec=vim.ResourcePool), None))
 
         params = pv_service.CloneVmParameters(si=si,
                                               template_name='my_temp',
@@ -153,7 +153,7 @@ class TestVmomiService(unittest.TestCase):
         pv_service.get_obj = Mock()
         pv_service.get_folder = Mock(return_value=datacenter)
         pv_service._get_datastore = Mock(return_value=Mock(spec=vim.Datastore))
-        pv_service._get_resource_pool = Mock(return_value=(Mock(spec=vim.ResourcePool), None))
+        pv_service.get_resource_pool = Mock(return_value=(Mock(spec=vim.ResourcePool), None))
 
         params = pv_service.CloneVmParameters(si=si,
                                               template_name='my_temp',
@@ -195,7 +195,7 @@ class TestVmomiService(unittest.TestCase):
         pv_service.get_obj = Mock()
         pv_service.get_folder = Mock(return_value=folder)
         pv_service._get_datastore = Mock(return_value=Mock(spec=vim.Datastore))
-        pv_service._get_resource_pool = Mock(return_value=Mock(spec=vim.ResourcePool))
+        pv_service.get_resource_pool = Mock(return_value=Mock(spec=vim.ResourcePool))
 
         params = pv_service.CloneVmParameters(si=si,
                                               template_name='my_temp',
@@ -233,7 +233,7 @@ class TestVmomiService(unittest.TestCase):
         pv_service.get_obj = Mock()
         pv_service.get_folder = Mock(return_value=folder)
         pv_service._get_datastore = Mock(return_value=Mock(spec=vim.Datastore))
-        pv_service._get_resource_pool = Mock(return_value=(Mock(spec=vim.ResourcePool), None))
+        pv_service.get_resource_pool = Mock(return_value=(Mock(spec=vim.ResourcePool), None))
 
         params = pv_service.CloneVmParameters(si=si,
                                               template_name='my_temp',
@@ -273,7 +273,7 @@ class TestVmomiService(unittest.TestCase):
         pv_service.get_obj = Mock()
         pv_service.get_folder = Mock(return_value=datacenter)
         pv_service._get_datastore = Mock(return_value=Mock(spec=vim.Datastore))
-        pv_service._get_resource_pool = Mock(return_value=(Mock(spec=vim.ResourcePool), None))
+        pv_service.get_resource_pool = Mock(return_value=(Mock(spec=vim.ResourcePool), None))
 
         params = pv_service.CloneVmParameters(si=si,
                                               template_name='my_temp',


### PR DESCRIPTION
…under hostsystem, not just under cluster or datacenter

## Description
Bug 172390:vCenter Autodiscovery: resource pool not identified if it is under host instead of cluster or datacenter

## Related Stories
Bug 172390:vCenter Autodiscovery: resource pool not identified if it is under host instead of cluster or datacenter

## Breaking
YES | NO

## Breaking changes
- ### Breaking change description
      Detailed change info 
      Migration steps

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/vcentershell/976)
<!-- Reviewable:end -->
